### PR TITLE
Cover `simple indent` case

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import ast
+from io import StringIO
+from tokenize import generate_tokens
 from typing import Optional
 
 import pytest
@@ -13,5 +15,7 @@ def run_plugin():
         if strip_tabs:
             tabs = strip_tabs * 4
             code_str = '\n'.join([line[tabs:] for line in code_str.strip('\n').split('\n')])
-        return {'{}:{}: {}'.format(*r) for r in Plugin(ast.parse(code_str)).run()}
+        tree = ast.parse(code_str)
+        tokens = list(generate_tokens(StringIO(code_str).readline))
+        return {'{}:{}: {}'.format(*r) for r in Plugin(tree=tree, file_tokens=tokens).run()}
     return wrapper

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -315,6 +315,18 @@ class Case25:
     """
 
 
+@register_case
+class Case26:
+    errors = None
+    code = """
+    def foo():
+        my_func({(
+            'name',
+            'hello'
+        )})
+    """
+
+
 @pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
 def test_plugin_on_func_call(run_plugin, case):
     """Test plugin on function calls."""

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -228,7 +228,7 @@ class Case17:
 
 @register_case
 class Case18:
-    errors = [Messages.FHG002, Messages.FHG005]
+    errors = [Messages.FHG002, Messages.FHG005, Messages.FHG007]
     code = """
     def foo():
         if use_shap:
@@ -239,7 +239,7 @@ class Case18:
 
 @register_case
 class Case19:
-    errors = [Messages.FHG002, Messages.FHG005]
+    errors = [Messages.FHG002, Messages.FHG005, Messages.FHG007]
     code = """
     if a != b:
         error_message = get_error_message(param,
@@ -305,7 +305,7 @@ class Case24:
 
 @register_case
 class Case25:
-    errors = [Messages.FHG006]
+    errors = [Messages.FHG006, Messages.FHG007]
     code = """
     def foo():
         result = my_func(

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -327,6 +327,28 @@ class Case26:
     """
 
 
+@register_case
+class Case27:
+    errors = None
+    code = """
+    def foo():
+        my_func({(
+            'name'
+        )})
+    """
+
+
+@register_case
+class Case28:
+    errors = None
+    code = """
+    def foo():
+        my_func({(  # comment with brackets ((
+            123
+        )})
+    """
+
+
 @pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
 def test_plugin_on_func_call(run_plugin, case):
     """Test plugin on function calls."""

--- a/tests/test_simple_indent.py
+++ b/tests/test_simple_indent.py
@@ -1,26 +1,72 @@
-"""
-NOTE: These cases are not implemented yet
-"""
 import pytest
 
-incorrect_1 = """
-predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
-                   else predicted_columns)
-"""
+from flake8_hangover.plugin import Messages
+
+CLASSES_REGISTRY = {}
 
 
-@pytest.mark.parametrize('value, error_messages', (
-    (incorrect_1, None),
-))
-def test_plugin_on_simple_indentation(run_plugin, value, error_messages):
-    """Test plugin on simple indentation.
+def register_case(_class):
+    """Decorator to register case class."""
+    name = _class.__name__
+    if name in CLASSES_REGISTRY:
+        raise ValueError(f'Case "{name}" already exists')
+    CLASSES_REGISTRY[name] = _class
+    return _class
 
-    TODO: This check is not yet implemented.
+
+@register_case
+class Case1:
+    errors = [Messages.FHG007]
+    code = """
+    predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
+                    else predicted_columns)
     """
-    error_lines = list(run_plugin(value))
-    if error_messages:
-        assert len(error_lines) == len(error_messages)
-        for i, msg in enumerate(error_messages):
-            assert error_lines[i].endswith(msg)
+
+
+@register_case
+class Case2:
+    errors = [Messages.FHG007]
+    code = """
+    predicted = ([predicted_columns] if isinstance(predicted_columns, str)
+                    else predicted_columns
+        )
+    """
+
+
+@register_case
+class Case3:
+    errors = None
+    code = """
+    predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
+                    else predicted_columns
+    )
+    """
+
+
+@register_case
+class Case4:
+    errors = None
+    code = """
+    predicted = (
+        [predicted_columns] if isinstance(predicted_columns, str)
+        else predicted_columns
+    )
+    """
+
+
+@pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
+def test_plugin_simple_indent(run_plugin, case):
+    """Test plugin on simple indentation."""
+    code, expected_errors = case.code, sorted(case.errors or [])
+    found_errors = sorted(list(run_plugin(code, strip_tabs=1)))
+
+    if expected_errors:
+        assert len(found_errors) == len(expected_errors), f'Case "{case.__name__}" failed'
+        for i, msg in enumerate(expected_errors):
+            assert found_errors[i].endswith(msg), (
+                f'Case "{case.__name__}" failed.\n'
+                f'Error: {found_errors[i]}\n'
+                f'Expected: {msg}'
+            )
     else:
-        assert not error_lines
+        assert not found_errors


### PR DESCRIPTION
**Review #3 at first**

**covered case from test**
```python
predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
                else predicted_columns)

# FHG007 Assignment close bracket must be on new line
```

**Downside** - mix of `assign` + `call` generate too many similar errors:
```python
error_message = get_error_message(param,
                                    other_param)

# 2:37: FHG002 Function call positional argument has hanging indentation
# 2:49: FHG007 Assignment close bracket must be on new line
# 2:49: FHG005 Function close bracket must be on new line
```
