### PR TITLE
Improve FHG006, added FHG007, added CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: tests
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: [3.8, 3.9, '3.10', '3.11-dev']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      id: python
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: pipenv
+    - name: pipenv
+      run: python -m pip install pipenv
+    - name: dependencies
+      if: steps.python.outputs.cache-hit != 'true'
+      run: pipenv install --deploy --dev
+    - name: flake8
+      run: pipenv run flake8 .
+    - name: mypy
+      run: pipenv run mypy .
+    - name: pytest
+      run: PYTHONPATH=. pipenv run pytest --cov --cov-report=term-missing

--- a/flake8_hangover/plugin.py
+++ b/flake8_hangover/plugin.py
@@ -127,7 +127,9 @@ class Visitor(ast.NodeVisitor):
             return
         start_line_tokens = self._get_tokens_for_line(start_lineno)
         start_indent = self._get_indent(start_line_tokens)
-        open_brackets = sum((count_parentheses(0, token.string) for token in start_line_tokens))
+        open_brackets = sum((
+            count_parentheses(0, token.string) for token in start_line_tokens if token.string
+        ))
         # all opened brackets on line with assign started should be closed on last assign` line
         if end_offset != start_indent + open_brackets:
             self.errors.append((end_lineno, end_offset, Messages.FHG007))

--- a/flake8_hangover/plugin.py
+++ b/flake8_hangover/plugin.py
@@ -77,7 +77,7 @@ class Visitor(ast.NodeVisitor):
                     self.errors.append((lineno, col_offset, Messages.FHG003))
 
             cur_lineno = getattr(kwarg, 'end_lineno', lineno)
-            if kwarg.lineno != node.lineno:
+            if getattr(kwarg, 'lineno', lineno) != node.lineno:
                 last_inner_lineno = max(last_inner_lineno, cur_lineno)
 
         if node.lineno != cur_lineno:  # skip one-liners

--- a/flake8_hangover/plugin.py
+++ b/flake8_hangover/plugin.py
@@ -192,6 +192,8 @@ class Visitor(ast.NodeVisitor):
         for token in tokens:
             if token.type == tokenize.INDENT:
                 return token.end[1]
+        if tokens:
+            return tokens[0].start[1]
         return 0
 
     def _count_brackets(self, lineno: int, start_offset: int, find_open: bool) -> int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,8 @@ branch = True
 source = .
 omit =
     */tests/*
+    ./fabfile.py
+    ./setup.py
 
 [coverage:report]
 fail_under = 80

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import ast
+from io import StringIO
+from tokenize import generate_tokens
 from typing import Optional
 
 import pytest
@@ -13,5 +15,7 @@ def run_plugin():
         if strip_tabs:
             tabs = strip_tabs * 4
             code_str = '\n'.join([line[tabs:] for line in code_str.strip('\n').split('\n')])
-        return {'{}:{}: {}'.format(*r) for r in Plugin(ast.parse(code_str)).run()}
+        tree = ast.parse(code_str)
+        tokens = list(generate_tokens(StringIO(code_str).readline))
+        return {'{}:{}: {}'.format(*r) for r in Plugin(tree=tree, file_tokens=tokens).run()}
     return wrapper

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -315,6 +315,18 @@ class Case25:
     """
 
 
+@register_case
+class Case26:
+    errors = None
+    code = """
+    def foo():
+        my_func({(
+            'name',
+            'hello'
+        )})
+    """
+
+
 @pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
 def test_plugin_on_func_call(run_plugin, case):
     """Test plugin on function calls."""

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -228,7 +228,7 @@ class Case17:
 
 @register_case
 class Case18:
-    errors = [Messages.FHG002, Messages.FHG005]
+    errors = [Messages.FHG002, Messages.FHG005, Messages.FHG007]
     code = """
     def foo():
         if use_shap:
@@ -239,7 +239,7 @@ class Case18:
 
 @register_case
 class Case19:
-    errors = [Messages.FHG002, Messages.FHG005]
+    errors = [Messages.FHG002, Messages.FHG005, Messages.FHG007]
     code = """
     if a != b:
         error_message = get_error_message(param,
@@ -305,7 +305,7 @@ class Case24:
 
 @register_case
 class Case25:
-    errors = [Messages.FHG006]
+    errors = [Messages.FHG006, Messages.FHG007]
     code = """
     def foo():
         result = my_func(

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -327,6 +327,28 @@ class Case26:
     """
 
 
+@register_case
+class Case27:
+    errors = None
+    code = """
+    def foo():
+        my_func({(
+            'name'
+        )})
+    """
+
+
+@register_case
+class Case28:
+    errors = None
+    code = """
+    def foo():
+        my_func({(  # comment with brackets ((
+            123
+        )})
+    """
+
+
 @pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
 def test_plugin_on_func_call(run_plugin, case):
     """Test plugin on function calls."""

--- a/tests/test_simple_indent.py
+++ b/tests/test_simple_indent.py
@@ -1,26 +1,72 @@
-"""
-NOTE: These cases are not implemented yet
-"""
 import pytest
 
-incorrect_1 = """
-predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
-                   else predicted_columns)
-"""
+from flake8_hangover.plugin import Messages
+
+CLASSES_REGISTRY = {}
 
 
-@pytest.mark.parametrize('value, error_messages', (
-    (incorrect_1, None),
-))
-def test_plugin_on_simple_indentation(run_plugin, value, error_messages):
-    """Test plugin on simple indentation.
+def register_case(_class):
+    """Decorator to register case class."""
+    name = _class.__name__
+    if name in CLASSES_REGISTRY:
+        raise ValueError(f'Case "{name}" already exists')
+    CLASSES_REGISTRY[name] = _class
+    return _class
 
-    TODO: This check is not yet implemented.
+
+@register_case
+class Case1:
+    errors = [Messages.FHG007]
+    code = """
+    predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
+                    else predicted_columns)
     """
-    error_lines = list(run_plugin(value))
-    if error_messages:
-        assert len(error_lines) == len(error_messages)
-        for i, msg in enumerate(error_messages):
-            assert error_lines[i].endswith(msg)
+
+
+@register_case
+class Case2:
+    errors = [Messages.FHG007]
+    code = """
+    predicted = ([predicted_columns] if isinstance(predicted_columns, str)
+                    else predicted_columns
+        )
+    """
+
+
+@register_case
+class Case3:
+    errors = None
+    code = """
+    predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
+                    else predicted_columns
+    )
+    """
+
+
+@register_case
+class Case4:
+    errors = None
+    code = """
+    predicted = (
+        [predicted_columns] if isinstance(predicted_columns, str)
+        else predicted_columns
+    )
+    """
+
+
+@pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
+def test_plugin_simple_indent(run_plugin, case):
+    """Test plugin on simple indentation."""
+    code, expected_errors = case.code, sorted(case.errors or [])
+    found_errors = sorted(list(run_plugin(code, strip_tabs=1)))
+
+    if expected_errors:
+        assert len(found_errors) == len(expected_errors), f'Case "{case.__name__}" failed'
+        for i, msg in enumerate(expected_errors):
+            assert found_errors[i].endswith(msg), (
+                f'Case "{case.__name__}" failed.\n'
+                f'Error: {found_errors[i]}\n'
+                f'Expected: {msg}'
+            )
     else:
-        assert not error_lines
+        assert not found_errors


### PR DESCRIPTION
## Several fixes

#### added CI

#### fixed FHG006 triggering on stylish parenthesis (missed in ast)

```python3
# OK
func({(
    123,
)})

# OK
Class().func({(  # text
    123
)})
```

#### covered `simple indent` case from test (FHG007)

```python3
predicted: list = ([predicted_columns] if isinstance(predicted_columns, str)
                else predicted_columns)

# FHG007 Assignment close bracket must be on new line
```

Downside - mix of assign + call generate too many similar errors:

```python3
error_message = get_error_message(param,
                                    other_param)

# 2:37: FHG002 Function call positional argument has hanging indentation
# 2:49: FHG007 Assignment close bracket must be on new line
# 2:49: FHG005 Function close bracket must be on new line
```

#### reworked FHG006 via tokens (somehow `keyword` ast does not have `col_offset` property in CI pythons)