### PR TITLE
Allow pipenv use different python version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       run: python -m pip install pipenv
     - name: dependencies
       if: steps.python.outputs.cache-hit != 'true'
-      run: pipenv install --deploy --dev
+      run: pipenv install --deploy --dev --python ${{ matrix.python-version }}
     - name: flake8
       run: pipenv run flake8 .
     - name: mypy

--- a/Pipfile
+++ b/Pipfile
@@ -3,9 +3,6 @@ url = 'https://pypi.python.org/simple'
 verify_ssl = true
 name = 'pypi'
 
-[requires]
-python_version = '3.8'
-
 [packages]
 flake8 = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,12 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "73c0673919fdc2dfb14a46e45fc05f078b2f4fcf51b7d32c0f31ef19aca9e2a6"
+            "sha256": "70943438ab9cdfdf6eec4673899008b0d95e50a85dc832c8b6f5713364e6d6c9"
         },
         "pipfile-spec": 6,
-        "requires": {
-            "python_version": "3.8"
-        },
+        "requires": {},
         "sources": [
             {
                 "name": "pypi",


### PR DESCRIPTION
Before pipenv always tries use python 3.8 as was specified in Pipfile.