### PR TITLE
fixed FHG006 falses

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,57 @@ def test_something(
     ...
 ```
 
-# TODO: Not yet implemented cases
+## FHG005 Function close bracket must be on new line
 
-Hanging indentation in cases with brackets like this is not yet checked by linter:
 ```python
-# Hanging indentation on `World`
-my_string = ('Hello '
-             'World')
+# ERROR: Close bracket on line with last parameter not allowed
+func(
+    123,
+    456)
+```
+
+```python
+# OK: Close bracket on new line
+func(
+    123,
+    456,
+)
+```
+
+## FHG006 Function close bracket got over indentation
+
+It mostly overlapping [E123](https://www.flake8rules.com/rules/E123.html), but a bit wider.
+
+```python
+# ERROR: Function close bracket over indented to the right
+func({
+    {
+        'key': 'value',
+    }})
+```
+
+```python
+# OK: Close bracket aligned with first line
+func({
+    {
+        'key': 'value',
+    }
+})
+```
+
+## FHG007 Assignment close bracket got over indentation
+
+```python
+# ERROR: Close bracket not aligned with open bracket's line
+result = [
+    1,
+    2]
+```
+
+```python
+# OK: Close bracket aligned with first line
+result = [
+    1,
+    2,
+]
 ```

--- a/flake8_hangover/plugin.py
+++ b/flake8_hangover/plugin.py
@@ -126,7 +126,9 @@ class Visitor(ast.NodeVisitor):
         start_line_tokens = self._get_tokens_for_line(start_lineno)
         start_indent = self._get_indent(start_line_tokens)
         open_brackets = sum((
-            count_parentheses(0, token.string) for token in start_line_tokens if token.string
+            count_parentheses(0, token.string)
+            for token in start_line_tokens
+            if token.string and token.start[1] >= start_offset
         ))
         # all opened brackets on line with assign started should be closed on last assign` line
         if open_brackets and end_offset != start_indent + open_brackets:

--- a/tests/test_func_call.py
+++ b/tests/test_func_call.py
@@ -423,6 +423,16 @@ class Case34:
     """
 
 
+@register_case
+class Case35:
+    errors = None
+    code = """
+    result = [Class(
+        kw='',
+    )]
+    """
+
+
 @pytest.mark.parametrize('case', CLASSES_REGISTRY.values())
 def test_plugin_on_func_call(run_plugin, case):
     """Test plugin on function calls."""


### PR DESCRIPTION
1. Fixed case with call inside other brackets (now no errors in code below)
```python
    result = [Class(
        kw='',
    )]
```

2. Updated readme with new rules